### PR TITLE
issue #40: if hover not supported, don't use hover effects on cards or buttons

### DIFF
--- a/src/components/GamePanel.js
+++ b/src/components/GamePanel.js
@@ -19,13 +19,6 @@ const GamePanel = () => {
         margin: 5px;
         padding: 2px;
         transition: 0.5s all ease-out;
-        &:hover {
-            background: url("img/sacred-geo.svg");
-            background-size: 40%;
-            background-color: ${accentColor};
-            color: black;
-            border: 2px solid darkblue;
-        }
     `
     const HintButton = styled(Button) `
         width: 50vw;
@@ -138,9 +131,9 @@ const GamePanel = () => {
     return (
 
         <ControlPanel>
-            <Button onClick={startNewGame}>New Game</Button>
+            <Button className="button" onClick={startNewGame}>New Game</Button>
             <Score>{score}</Score>
-            <Button onClick={addCards}>Add Cards</Button>
+            <Button className="button" onClick={addCards}>Add Cards</Button>
             <HintButton onClick={showHint}>Hint</HintButton>
         </ControlPanel>
     )

--- a/src/components/SetsCard.js
+++ b/src/components/SetsCard.js
@@ -43,10 +43,6 @@ const SetsCard = ({id, color, number, shape, fill}) => {
         width: ${cardWidth}px;
         transition: 0.5s all ease-out;
         background-color: ${cardSelected ? selectedColor : "white"};
-        &:hover {
-            border: 2px solid red;
-            background-color: ${selectedColor}
-        }
     `
 
     // Creates the card shapes and fill
@@ -83,7 +79,7 @@ const SetsCard = ({id, color, number, shape, fill}) => {
     }
 
     return (
-        <Card onClick={() => selectCardAction(id)} >
+        <Card className="card" onClick={() => selectCardAction(id)} >
             { number.map((key) => 
                 (fill === "fill") 
                 ? <CardShape key={key} className="fill" /> 

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -1,5 +1,25 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto|Amarante&display=swap');
 
+$selectedColor: rgba(0,200,255,.3);
+$accentColor: rgba(0,200,255,.5);
+
 .fill {
     mask: url("sacred-flower.svg");
+}
+
+@media (hover: hover) {
+   .card { 
+        &:hover {
+            border: 2px solid red;
+            background-color: $selectedColor;
+        }
+    }
+    .button {
+        &:hover {
+            background-size: 40%;
+            background-color: $accentColor;
+            color: black;
+            border: 2px solid darkblue;
+        }
+    }
 }


### PR DESCRIPTION
Remove hover effect on cards and new game/add card buttons when hover isn't supported on device. It made it look like you could not de-select cards on mobile.